### PR TITLE
Supports content with 'absolute' positioning

### DIFF
--- a/angular-vertilize.js
+++ b/angular-vertilize.js
@@ -75,6 +75,7 @@
                 left: 0,
                 visibility: 'hidden'
               });
+            clone.find('*').css('position', 'relative')
             element.after(clone);
             var realHeight = clone.height();
             clone['remove']();


### PR DESCRIPTION
I have a card-style application that has absolute positioning of the footer within the card. 

This pull request correctly aligns the heights when this absolute-positioned content is present in child elements, which would normally be treated as zero height. I simply switch the absolute positioning for relative positioning for the purposes of the height calculation.

I have only modified angular-vertilize.js, not the minified version.

Its up to you if you include this - perhaps there are situations where I absolute positioned content might need to be handled in a different way. Maybe it needs to be configurable through a attribute on the directives?

Cheers, 
Nigel (@wtfiwtz)