### PR TITLE
Get width of element with border and padding.

### DIFF
--- a/angular-vertilize.js
+++ b/angular-vertilize.js
@@ -46,7 +46,7 @@
             // Add window resize to digest cycle
             angular.element($window).bind('resize', function(){
               return $scope.$apply();
-            });            
+            });
           }
         ]
       };
@@ -69,7 +69,7 @@
               .removeAttr('vertilize')
               .css({
                 height: '',
-                width: element.width(),
+                width: element.outerWidth(),
                 position: 'fixed',
                 top: 0,
                 left: 0,


### PR DESCRIPTION
Hiya buddy!

Noticed a weird bug in my super interesting project where the height wasn't being calculated correctly because the width was off, thus forcing the height of the container.

This PR use .outerWidth to get the cloned elements width with padding and border instead of .width.

I didn't update the minified version of the JS because I'm not sure what tasks you're running on it to get it minified.