### PR TITLE
Deal with vertical margins and fractions of heights

### DIFF
--- a/angular-vertilize.js
+++ b/angular-vertilize.js
@@ -60,6 +60,10 @@
         restrict: 'EA',
         require: '^vertilizeContainer',
         link: function(scope, element, attrs, parent){
+				
+					// Get scale
+					var scale = (attrs.vertilize)?(attrs.vertilize):(1);
+					
           // My index allocation
           var myIndex = parent.allocateMe();
 
@@ -76,7 +80,7 @@
                 visibility: 'hidden'
               });
             element.after(clone);
-            var realHeight = clone.height();
+            var realHeight = (1/scale)*clone.outerHeight(true);
             clone['remove']();
             return realHeight;
           };
@@ -91,7 +95,7 @@
           // Watch for tallest height change
           scope.$watch(parent.getTallestHeight, function(tallestHeight){
             if (tallestHeight){
-              element.css('height', tallestHeight);
+              element.outerHeight(scale*tallestHeight, true);
             }
           });
         }


### PR DESCRIPTION
I've added two extensions....

Deal with vertical margins:
By calculating the height of an object with .outerHeight(true) and setting the new height the same way it's possible to include margins in the calculation. This makes especially sense in combination with the other extension.

Deal with fractions of the height:
The idea is that if you have some kind of a setup with boxes where some boxes must be exactly half the height of the other boxes you can specify the fraction with "vertilize='0.5'". If you leave it out (just use "vertilize") it defaults to 1 which leads to the default behaviour. It allows to have any fraction, i.e. half, third, quarter, ...

If you have equal margins on the full and half boxes in such a setup then the combination of the two leads to a layout where you have the backgrounds horizontally aligned.

![grid](https://cloud.githubusercontent.com/assets/13888122/9385957/7b421082-4759-11e5-8adb-5c71a4f011fe.png)
