### PR TITLE
Use the outerHeight as measure

### DIFF
--- a/angular-vertilize.js
+++ b/angular-vertilize.js
@@ -76,7 +76,7 @@
                 visibility: 'hidden'
               });
             element.after(clone);
-            var realHeight = clone.height();
+            var realHeight = clone.outerHeight();
             clone['remove']();
             return realHeight;
           };


### PR DESCRIPTION
It seems that when calculating heights, it fails to correctly take into account when the content has margins and paddings.