### PR TITLE
Bind window to click events to empty children no longer in view

### DIFF
--- a/angular-vertilize.js
+++ b/angular-vertilize.js
@@ -47,6 +47,10 @@
             angular.element($window).bind('resize', function(){
               return $scope.$apply();
             });
+
+            angular.element($window).bind('click', function(){
+              _this.childrenHeights = [];
+            });
           }
         ]
       };


### PR DESCRIPTION
This PR empties the `childrenHeights` array on click events so child elements no longer in the view are not influencing the `getTallestHeight` calculation.
